### PR TITLE
Add DrawingMenu component. Adjust canvas styling

### DIFF
--- a/src/components/DrawingMenu.tsx
+++ b/src/components/DrawingMenu.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react"
+import PenColorButton from "./PenColorButton"
+
+function DrawingMenu() {
+    const [color, setColor] = useState("#000000")
+    const [penSize, setPenSize] = useState(1)
+
+    const penColors = [
+        "#000000", "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff"
+    ]
+
+    const penSizeIncrementAmount = 1
+    const penSizeHandler = (incrementAmount: number) => {
+        if(penSize + incrementAmount >= 1) {
+            setPenSize(penSize + incrementAmount)
+        } else {
+            setPenSize(1)
+        }
+    }
+
+    return (
+        <>
+            <div className="flex flex-row gap-3">
+                {penColors.map(color => <PenColorButton color={color} onClick={() => setColor(color)} />)}
+                <button className="bg-gray-500 hover:bg-gray-600 text-white px-2 py-1 rounded text-1xl">Clear canvas</button>
+            </div>
+            <p className="text-white">Pen color: {color}</p>
+            <div className="flex flex-row gap-3 mt-2">
+                <p className="text-white">Pen size: {penSize}</p>
+                <button className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 w-8 h-8 rounded text-1xl"
+                onClick={() => penSizeHandler(-penSizeIncrementAmount)}>-</button>
+                <button className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 w-8 h-8 rounded text-1xl"
+                onClick={() => penSizeHandler(penSizeIncrementAmount)}>+</button>
+            </div>
+        </>
+    )
+}
+
+export default DrawingMenu

--- a/src/components/DrawingMenu.tsx
+++ b/src/components/DrawingMenu.tsx
@@ -6,7 +6,8 @@ function DrawingMenu() {
     const [penSize, setPenSize] = useState(1)
 
     const penColors = [
-        "#000000", "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff"
+        "#000000", "#ffffff", "#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff",
+        "#ffa500", "#008080", "#654321", "#03fca1", "#ffb8e8", "#facfa7"
     ]
 
     const penSizeIncrementAmount = 1

--- a/src/components/GamePage.tsx
+++ b/src/components/GamePage.tsx
@@ -1,3 +1,5 @@
+import DrawingMenu from "./DrawingMenu"
+
 interface GamePageInterface{
     changeStage: Function,
 }
@@ -7,13 +9,14 @@ function GamePage({changeStage}: GamePageInterface) {
     return (
         <div className="flex flex-col items-center gap-3 bg-gray-800 h-screen">
             <button className="bg-red-600 hover:bg-red-700 text-white px-2 py-1 rounded text-xl" onClick={()=>changeStage(-1)}>LEAVE</button>
-            <div className="flex flex-row">
-                <canvas width={100} height={100}></canvas>
+            <div className="flex flex-row gap-3">
+                <canvas width={200} height={200} className="border-2 border-black"></canvas>
                 <div>   
-                    <div>Zgadywane teksty</div>
+                    <div className="text-white">Zgadywane teksty</div>
                     <input type="text"></input>
                 </div>
             </div>
+            <DrawingMenu />
         </div>
     )
 }

--- a/src/components/PenColorButton.tsx
+++ b/src/components/PenColorButton.tsx
@@ -1,0 +1,13 @@
+interface PenColorButtonProps {
+    color: string,
+    onClick: () => void
+}
+
+function PenColorButton({color, onClick}: PenColorButtonProps) {
+    return (
+        <div style={{backgroundColor: color}} className="w-8 h-8 hover:cursor-pointer" onClick={onClick}>
+        </div>
+    )
+}
+
+export default PenColorButton


### PR DESCRIPTION
The DrawingMenu has pickable colors, clear canvas button, current color indicator and pen size buttons.
Adjusted canvas size and styling so that the canvas is visible on the page.

Closes #17 